### PR TITLE
添加Go代码发布工作流

### DIFF
--- a/.github/workflows/go-tag-release.yml
+++ b/.github/workflows/go-tag-release.yml
@@ -1,0 +1,107 @@
+name: Publish Go Code
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - '*'   # 匹配所有标签
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.4' # 根据需要指定Go版本
+
+      - name: Test
+        run: |
+          go test ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.4' # 根据需要指定Go版本
+
+      - name: Build
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_lionv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
+          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1
+          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_catv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/catv1
+
+      - name: List build directory
+        run: |
+          ls -l "${{ github.workspace }}/output"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux_amd64_executable_files
+          path: "${{ github.workspace }}/output/"
+          if-no-files-found: error
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions: write-all
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 获取所有历史记录以便能够创建标签
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux_amd64_executable_files
+          path: ${{ github.workspace }}/output
+
+      - name: List directory
+        run: ls -l ${{ github.workspace }}/output
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "${{ github.workspace }}/output/linux_amd64_lionv1,${{ github.workspace }}/output/linux_amd64_tigerv1,${{ github.workspace }}/output/linux_amd64_catv1"
+          artifactErrorsFailBuild: true
+          allowUpdates: false
+          body: |
+            新版本 ${{  github.ref  }} 发布啦！
+            快来体验吧！
+          generateReleaseNotes: true
+          makeLatest: "legacy"
+          tag: "${{  github.ref  }} "
+
+      - name: Output the URL of the new release
+        run: echo "The release is available at ${{ steps.create_release.outputs.html_url }}"
+    outputs:
+      tag: "${{  github.ref  }}"
+      release: "${{ steps.create_release.outputs.html_url }}"

--- a/.github/workflows/go-tag-release.yml
+++ b/.github/workflows/go-tag-release.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Test
         run: |
-          go test ./...
+          GOOS=linux GOARCH=amd64 go generate ./...
+          GOOS=linux GOARCH=amd64 go test ./...
 
   build:
     runs-on: ubuntu-latest
@@ -49,6 +50,7 @@ jobs:
 
       - name: Build
         run: |
+          GOOS=linux GOARCH=amd64 go generate ./...
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_lionv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_catv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/catv1

--- a/.github/workflows/go-tag-release.yml
+++ b/.github/workflows/go-tag-release.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Test
         run: |
+          GOOS=linux GOARCH=amd64 go mod tidy
           GOOS=linux GOARCH=amd64 go generate ./...
           GOOS=linux GOARCH=amd64 go test ./...
 
@@ -50,6 +51,7 @@ jobs:
 
       - name: Build
         run: |
+          GOOS=linux GOARCH=amd64 go mod tidy
           GOOS=linux GOARCH=amd64 go generate ./...
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_lionv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1

--- a/.github/workflows/go-tag-release.yml
+++ b/.github/workflows/go-tag-release.yml
@@ -60,15 +60,15 @@ jobs:
 
       - name: Build lionv1
         run: |
-          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_lionv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
+          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_lionv1" -trimpath -ldflags='-s -w -extldflags "-static"' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
 
       - name: Build tigerv1
         run: |
-          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1
+          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1
 
       - name: Build catv1
         run: |
-          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_catv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/catv1
+          GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_catv1" -trimpath -ldflags='-s -w -extldflags "-static"' github.com/SongZihuan/BackendServerTemplate/src/cmd/catv1
 
       - name: List build directory
         run: |

--- a/.github/workflows/go-tag-release.yml
+++ b/.github/workflows/go-tag-release.yml
@@ -66,11 +66,9 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1
 
-
       - name: Build catv1
         run: |
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_catv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/catv1
-
 
       - name: List build directory
         run: |

--- a/.github/workflows/go-tag-release.yml
+++ b/.github/workflows/go-tag-release.yml
@@ -29,11 +29,14 @@ jobs:
         with:
           go-version: '1.23.4' # 根据需要指定Go版本
 
+      - name: Download module
+        run: GOOS=linux GOARCH=amd64 go mod tidy
+
+      - name: Go generate
+        run: GOOS=linux GOARCH=amd64 go generate ./...
+
       - name: Test
-        run: |
-          GOOS=linux GOARCH=amd64 go mod tidy
-          GOOS=linux GOARCH=amd64 go generate ./...
-          GOOS=linux GOARCH=amd64 go test ./...
+        run: GOOS=linux GOARCH=amd64 go test ./...
 
   build:
     runs-on: ubuntu-latest
@@ -49,13 +52,25 @@ jobs:
         with:
           go-version: '1.23.4' # 根据需要指定Go版本
 
-      - name: Build
+      - name: Download module
+        run: GOOS=linux GOARCH=amd64 go mod tidy
+
+      - name: Go generate
+        run: GOOS=linux GOARCH=amd64 go generate ./...
+
+      - name: Build lionv1
         run: |
-          GOOS=linux GOARCH=amd64 go mod tidy
-          GOOS=linux GOARCH=amd64 go generate ./...
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_lionv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
+
+      - name: Build tigerv1
+        run: |
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_tigerv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/tigerv1
+
+
+      - name: Build catv1
+        run: |
           GOOS=linux GOARCH=amd64 go build -o "${{ github.workspace }}/output/linux_amd64_catv1" -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=2' github.com/SongZihuan/BackendServerTemplate/src/cmd/catv1
+
 
       - name: List build directory
         run: |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ go build github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
 
 若用于开发环境，可以按如下方式编译：
 ```shell
-$ go build -o lionv1 -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='-O4 -inline=1' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
+$ go build -o lionv1 -trimpath -ldflags='-s -w -extldflags "-static"' github.com/SongZihuan/BackendServerTemplate/src/cmd/lionv1
 ```
 
 其中：
@@ -70,9 +70,6 @@ $ go build -o lionv1 -trimpath -ldflags='-s -w -extldflags "-static"' -gcflags='
    * `-w` 表示去掉`DWARF`调试信息，可以减少二进制文件大小，同时增加反编译的难度。
    * `-extldflags "-static"` 是传递给外部链接器的参数。
      * `-static` 表示外部链接器生成静态链接文件（实际上我几乎从真正看过这个参数的作用，因为`go`本身就会优先以静态形式链接库文件，这个参数可能和`cgo`搭配更合适）。
- * `-gcflags='-O4 -inline=1'` 是传递给编译器的参数。
-   * `-O4` 启用最大优化。
-   * `-inline=1` 内联的积极程度。支持-1、0、1、2、3。数值越大约积极，-1为禁止内联，0为默认模式。内联越积极，可以提高一定性能，但可能让二进制文件膨胀变大。
 
 ## 运行
 执行编译好地可执行文件即可。

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	github.com/kardianos/service v1.2.2 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	github.com/kardianos/service v1.2.2
+	github.com/mattn/go-isatty v0.0.20
+	gopkg.in/yaml.v3 v3.0.1
 )
+
+require golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/consolewatcher/posix.go
+++ b/src/consolewatcher/posix.go
@@ -6,6 +6,8 @@
 
 package consolewatcher
 
+import "github.com/SongZihuan/BackendServerTemplate/src/utils/consoleutils"
+
 func NewWin32ConsoleExitChannel() (chan consoleutils.Event, chan any, error) {
 	var exitChannel = make(chan consoleutils.Event)
 	var waitExitChannel = make(chan any)

--- a/src/utils/consoleutils/global.go
+++ b/src/utils/consoleutils/global.go
@@ -4,6 +4,11 @@
 
 package consoleutils
 
+const (
+	CodePageUTF8 uint = 65001
+	CodePageGBK  uint = 936
+)
+
 type Event interface {
 	String() string
 	ConsoleEvent()

--- a/src/utils/consoleutils/posix.go
+++ b/src/utils/consoleutils/posix.go
@@ -18,7 +18,7 @@ func BindStdToConsole() error {
 	return nil
 }
 
-func SetConsoleCtrlHandler(handler func(event uint) uintptr, add bool) error {
+func SetConsoleCtrlHandler(handler func(event uint) bool, add bool) error {
 	return nil
 }
 
@@ -34,18 +34,18 @@ func HasConsoleWindow() bool {
 	return GetConsoleWindow() != 0
 }
 
-func SetConsoleInputCP(codePage int) error {
+func SetConsoleInputCP(codePage uint) error {
 	return nil
 }
 
-func SetConsoleOutputCP(codePage int) error {
+func SetConsoleOutputCP(codePage uint) error {
 	return nil
 }
 
-func SetConsoleCP(codePage int) error {
+func SetConsoleCP(codePage uint) error {
 	return nil
 }
 
-func SetConsoleCPSafe(codePage int) error {
+func SetConsoleCPSafe(codePage uint) error {
 	return nil
 }

--- a/src/utils/consoleutils/win32.go
+++ b/src/utils/consoleutils/win32.go
@@ -12,11 +12,6 @@ import (
 	"syscall"
 )
 
-const (
-	CodePageUTF8 uint = 65001
-	CodePageGBK  uint = 936
-)
-
 var (
 	kernel32 = syscall.NewLazyDLL("kernel32.dll")
 


### PR DESCRIPTION
新增GitHub Actions工作流，用于在推送标签时自动测试、构建和发布Go项目。该工作流包括测试、构建Linux amd64架构的可执行文件以及创建GitHub Release。